### PR TITLE
Fix typo ... gt means greater-than not greater-or-equal

### DIFF
--- a/docs/source/narrative.rst
+++ b/docs/source/narrative.rst
@@ -584,7 +584,7 @@ The provided predicates are:
   ``lt_(value)``                ``lambda x: x < value``
   ``le_(value)``                ``lambda x: x <= value``
   ``ge_(value)``                ``lambda x: x >= value``
-  ``gt_(value)``                ``lambda x: x >= value``
+  ``gt_(value)``                ``lambda x: x > value``
   ``is_(value)``                ``lambda x: x is value``
   ``contains_(value)``          ``lambda x: value in x``
   ============================= ===============================================


### PR DESCRIPTION
Just a typo.